### PR TITLE
Fixes JAXB problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.235.1</jenkins.version>
+        <jenkins.version>2.319.1</jenkins.version>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>
@@ -57,8 +57,8 @@ THE SOFTWARE.
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>11</version>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1085.vc4c268262299</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -150,6 +150,11 @@ THE SOFTWARE.
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,6 @@ THE SOFTWARE.
                     <xnocompile>true</xnocompile>
                     <verbose>true</verbose>
                     <extension>true</extension>
-                    <catalog>${basedir}/src/jax-ws-catalog.xml</catalog>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.319.1</jenkins.version>
+        <jenkins.version>2.329</jenkins.version>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>

--- a/src/jax-ws-catalog.xml
+++ b/src/jax-ws-catalog.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <system systemId="file:/${project.basedir}/src/wsdl/HelperService.svc.singlewsdl.wsdl" uri="wsdl/HelperService.svc.singlewsdl.wsdl"/>
-    <system systemId="file:/${project.basedir}/src/wsdl/TeamWorkService2.svc.singlewsdl.wsdl" uri="wsdl/TeamWorkService2.svc.singlewsdl.wsdl"/>
-</catalog>

--- a/src/main/java/org/jenkinsci/plugins/genexus/helpers/XmlHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/genexus/helpers/XmlHelper.java
@@ -49,6 +49,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.jenkinsci.plugins.genexus.server.clients.common.WithLocalContextClassLoader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -79,7 +80,9 @@ public class XmlHelper {
     }
 
     public static <T> T parse(Document doc, Class<T> tClass) throws JAXBException {
-        JAXBContext jaxbContext = JAXBContext.newInstance(tClass);
+        JAXBContext jaxbContext = WithLocalContextClassLoader.call(() -> {
+            return JAXBContext.newInstance(tClass);
+        });
         Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
         T result = (T) jaxbUnmarshaller.unmarshal(doc);
         return result;

--- a/src/main/java/org/jenkinsci/plugins/genexus/server/clients/TeamWorkService2Client.java
+++ b/src/main/java/org/jenkinsci/plugins/genexus/server/clients/TeamWorkService2Client.java
@@ -31,7 +31,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.logging.Level;


### PR DESCRIPTION
Fixes JAXB problems (errors while contacting GeneXus Server).

Bumps jenkins.version to 2.329 on which [JENKINS-67470](https://issues.jenkins.io/browse/JENKINS-67470) was fixed.

