### PR TITLE
Use UTF-8 by default for XmlStreamWriter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/genexus/helpers/XMLStreamWriterEx.java
+++ b/src/main/java/org/jenkinsci/plugins/genexus/helpers/XMLStreamWriterEx.java
@@ -37,7 +37,11 @@ import javax.xml.stream.XMLStreamWriter;
 public class XMLStreamWriterEx extends IndentingXMLStreamWriter implements AutoCloseable {
 
     public static XMLStreamWriterEx newInstance(OutputStream stream) throws XMLStreamException {
-        return new XMLStreamWriterEx(XMLOutputFactory.newInstance().createXMLStreamWriter(stream));
+        return newInstance(stream, "UTF-8");
+    }
+
+    public static XMLStreamWriterEx newInstance(OutputStream stream, String encoding) throws XMLStreamException {
+        return new XMLStreamWriterEx(XMLOutputFactory.newInstance().createXMLStreamWriter(stream, encoding));
     }
 
     public XMLStreamWriterEx(XMLStreamWriter actualWriter) {


### PR DESCRIPTION
Use UTF-8 on change logs to avoid encoding errors with special characters
