### PR TITLE
change revision file name to avoid conflicts in project also uses SVN

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/genexus/server/GeneXusServerSCM.java
+++ b/src/main/java/org/jenkinsci/plugins/genexus/server/GeneXusServerSCM.java
@@ -586,7 +586,7 @@ public class GeneXusServerSCM extends SCM implements Serializable {
      * @return File that stores the revision
      */
     public static File getRevisionFile(Run<?, ?> build) {
-        return new File(build.getRootDir(), "revision.txt");
+        return new File(build.getRootDir(), "GXServer_revision.txt");
     }
 
     @Override


### PR DESCRIPTION
The SVN plugin also uses a file called revision.txt.

In projects that use both SCMs, errors occur when the SVN plugin tries to read the file as the format written by this plugin is different.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
