### PR TITLE
Fix: Use GX and MSBuild custom paths when not empty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/genexus/server/GeneXusServerSCM.java
+++ b/src/main/java/org/jenkinsci/plugins/genexus/server/GeneXusServerSCM.java
@@ -185,12 +185,18 @@ public class GeneXusServerSCM extends SCM implements Serializable {
     }
 
     private String getGxPath(@CheckForNull FilePath workspace, @CheckForNull EnvVars env, @NonNull TaskListener listener) {
+        // check for custom path first
+        String customPath = getGxCustomPath();
+        if (customPath != null && !customPath.isEmpty()) {
+            return customPath;
+        }
+        
         GeneXusInstallation installation = getGeneXusInstallation(workspace, env, listener);
         if (installation != null) {
             return installation.getHome();
         }
 
-        return getGxCustomPath();
+        return "";
     }
 
     private String getMSBuildInstallationId(@CheckForNull FilePath workspace, @CheckForNull EnvVars env, @NonNull TaskListener listener) {
@@ -203,6 +209,12 @@ public class GeneXusServerSCM extends SCM implements Serializable {
     }
 
     private String getMsBuildPath(@CheckForNull FilePath workspace, @CheckForNull EnvVars env, @NonNull TaskListener listener) {
+        // check for custom path first
+        String customPath = getMsbuildCustomPath();
+        if (customPath != null && !customPath.isEmpty()) {
+            return customPath;
+        }
+
         String installationId = getMSBuildInstallationId(workspace, env, listener);
         Node node = workspaceToNode(workspace);
         MsBuildInstallation msbuildTool = MsBuildInstallationHelper.resolveInstallation(installationId, node, env, listener);
@@ -210,7 +222,7 @@ public class GeneXusServerSCM extends SCM implements Serializable {
             return msbuildTool.getHome();
         }
 
-        return getMsbuildCustomPath();
+        return "";
     }
 
     @Exported


### PR DESCRIPTION
When resolving GX and MSBuild paths, the optional custom paths were not taken unless there were no registered installations at all. It now checks and gives preference to custom paths.

### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
